### PR TITLE
feat(api/swagger): #11 - Adds basic swagger annotation with a sample …

### DIFF
--- a/api/google-search/pom.xml
+++ b/api/google-search/pom.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>2.4.1-SNAPSHOT</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath/>
+		<!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.google.search</groupId>
 	<artifactId>google-search</artifactId>
@@ -43,6 +44,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-ui</artifactId>
+			<version>1.5.1</version>
 		</dependency>
 	</dependencies>
 

--- a/api/google-search/src/main/java/com/google/search/googlesearch/controller/v1/api/SearchController.java
+++ b/api/google-search/src/main/java/com/google/search/googlesearch/controller/v1/api/SearchController.java
@@ -1,0 +1,21 @@
+package com.google.search.googlesearch.controller.v1.api;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@RestController
+public class SearchController {
+    @GetMapping(value = "/api/v1/search")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Get search results", content = @Content(schema = @Schema(nullable = true)))
+    })
+    public String getSearch(@RequestParam(defaultValue = "param") String query) {
+        return "Query: " + query;
+    }
+}

--- a/api/google-search/src/main/resources/application.properties
+++ b/api/google-search/src/main/resources/application.properties
@@ -1,1 +1,3 @@
-
+springdoc.swagger-ui.disable-swagger-default-url=true
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.path=/docs


### PR DESCRIPTION
## Steps To Implement Feature

1. Add spring library for Open API 3.0 to `pom.xml`

```xml
<dependency>
    <groupId>org.springdoc</groupId>
    <artifactId>springdoc-openapi-ui</artifactId>
    <version>1.5.1</version>
</dependency>
```

2. Add custom path from Open API page to `application.properties`

```properties
springdoc.swagger-ui.path=/docs
```

3. Add a controller to simulate an API to test swagger api.

```java
package com.google.search.googlesearch.controller.v1.api;

import org.springframework.web.bind.annotation.GetMapping;
import org.springframework.web.bind.annotation.RequestParam;
import org.springframework.web.bind.annotation.RestController;

import io.swagger.v3.oas.annotations.media.Content;
import io.swagger.v3.oas.annotations.media.Schema;
import io.swagger.v3.oas.annotations.responses.ApiResponse;
import io.swagger.v3.oas.annotations.responses.ApiResponses;

@RestController
public class SearchController {
    @GetMapping(value = "/api/v1/search")
    @ApiResponses(value = {
        @ApiResponse(responseCode = "200", description = "Get search results", content = @Content(schema = @Schema(nullable = true)))
    })
    public String getSearch(@RequestParam(defaultValue = "param") String query) {
        return "Query: " + query;
    }
}
```
resolves #11