### PR TITLE
test(Jacoco): Added Jacoco coverage report generation plugin.

### DIFF
--- a/api/google-search/pom.xml
+++ b/api/google-search/pom.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>2.4.1-SNAPSHOT</version>
-		<relativePath/>
+		<relativePath />
 		<!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.google.search</groupId>
@@ -51,14 +52,14 @@
 			<version>1.5.1</version>
 		</dependency>
 		<dependency>
-    		<groupId>org.springframework.data</groupId>
-    		<artifactId>spring-data-couchbase</artifactId>
-    		<version>4.0.0.RELEASE</version>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-couchbase</artifactId>
+			<version>4.0.0.RELEASE</version>
 		</dependency>
 		<dependency>
-     		<groupId>org.projectlombok</groupId>
-      		<artifactId>lombok</artifactId>
-    	</dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -66,6 +67,45 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.3</version>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>post-unit-test</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+						<configuration>
+							<!-- Sets the path to the file which contains the execution data. -->
+
+							<dataFile>target/jacoco.exec</dataFile>
+							<!-- Sets the output directory for the code coverage report. -->
+							<outputDirectory>target/my-reports</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
+				<configuration>
+					<systemPropertyVariables>
+						<jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
+					</systemPropertyVariables>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/web-slate/simple-google-search/blob/main/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What type of change does this PR introduce?

- [x] API
- [ ] Frontend

## PR Sub Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [x] Other... Please describe: Code Coverage


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #33


## What is the new behavior?
Introduced code coverage report generation with the help of Jacococ plugin. Which standardize the build process.

## Does this PR introduce a breaking change?

- [x] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
### Setup

- Modify `pom.xml` to support Jacoco plugin.
```xml
<plugin>
   <groupId>org.jacoco</groupId>
   <artifactId>jacoco-maven-plugin</artifactId>
   <version>0.8.3</version>
   <executions>
      <execution>
         <id>prepare-agent</id>
         <goals>
            <goal>prepare-agent</goal>
         </goals>
      </execution>
      <execution>
         <id>report</id>
         <phase>prepare-package</phase>
         <goals>
            <goal>report</goal>
         </goals>
      </execution>
      <execution>
         <id>post-unit-test</id>
         <phase>test</phase>
         <goals>
            <goal>report</goal>
         </goals>
         <configuration>
            <!-- Sets the path to the file which contains the execution data. -->
            <dataFile>target/jacoco.exec</dataFile>
            <!-- Sets the output directory for the code coverage report. -->
            <outputDirectory>target/my-reports</outputDirectory>
         </configuration>
      </execution>
   </executions>
   <configuration>
      <systemPropertyVariables>
         <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
      </systemPropertyVariables>
   </configuration>
</plugin>
```
- `Maven test` command will result in generating the coverage report on the `outputDIrectory` (target/my-reports)
- For Eclipse try Run As -> Maven test
- The report will be generated with `index.html` right click and open with browser to see the results like below
![image](https://user-images.githubusercontent.com/3478542/103511138-7299c480-4e8c-11eb-91f2-8ec52145de11.png)
- Further, drill down on your controller to check what are the lines which are not covered.

Ref link which I followed  https://www.youtube.com/watch?v=wL2DxBJDj_8
